### PR TITLE
Add goldenchaos-btt.json download links and screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,27 @@ Right:
 
 The brightness/volume up buttons were omitted from the slider in the interest of saving space, and because I use the slider to adjust and not the buttons. The buttons are effectively just icons to remind what each slider is for.
 
+### @goldenchaos: [goldenchaos-btt.json](https://raw.githubusercontent.com/GoldenChaos/GoldenChaos-BTT/master/goldenchaos-btt.json)
+
+![Photo](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/Cool%20Photo.jpg?raw=true)
+
+![Screenshot 6](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/Screenshot%208.png?raw=true)
+![Screenshot 5](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/Screenshot%205.png?raw=true)
+![Screenshot 1](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/Screenshot%201.png?raw=true)
+![Screenshot 2](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/Screenshot%202.png?raw=true)
+
+- Fullscreen button also acts as esc key
+- Date and Time widget toggles Fantastical 2 menu bar when pressed (uses Fantastical 2's default keyboard shortcut)
+- Weather widget toggles Carrot menu bar when pressed (uses Carrot's default keyboard shortcut)
+- Refresh button appears next to Forward and Back buttons if Safari is open
+- Media controls and iTunes widget appear only when iTunes is running
+- iTunes Now Playing widget shows currently playing song or "Paused" if iTunes is not playing anything
+- Due Today widget shows reminders from Reminders.app that are due today, overdue, or without a due date
+- Reminders without a due date persist and automatically show the most recently added reminder
+- Persistent Show Finder widget provides easy finder access
+- Persistent Maximize Left, Center Window, and Maximize Right controls (with custom glyphs!) for window management
+- Tap on any widget to open its parent app
+
 ## Useful links
 
 * [Original blog post (EN)](http://vas3k.com/blog/touchbar/)


### PR DESCRIPTION
I decided to give a go at creating a preset that would be more general-purpose and all-inclusive, with context-sensitive buttons that appear only when the proper app is open, ordered in the scrollable area by some combination of importance and common sense. A default set of buttons is always visible when nothing but Finder is open, but as you open more apps the button set vastly expands.

Along the way, I also fixed a major bug in the Reminders widget where the list it grabbed was ordered the wrong way, and also made sure that it's only showing reminders for the given day.

Finally, BetterTouchTool currently has a nasty bug that anytime a widget refreshes its background color gets reset to the default value. I made sure the buttons and widgets in my preset always look consistent despite this bug. The weird constraint actually led me to what I think is a much nicer-looking widget area, surprisingly!

The result:

![Screenshot 6](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/Screenshot%208.png?raw=true)
Default set of buttons with some custom glyphs for maximize left and right + center window buttons. Fullscreen button also doubles as esc key, saving space while adding functionality, and is the only thing always docked to the left.

![Screenshot 5](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/Screenshot%205.png?raw=true)
Buttons like Refresh and Media Controls appear when iTunes and Safari are open (Finder controls get pushed to the right)

![Screenshot](https://github.com/GoldenChaos/GoldenChaos-BTT/raw/master/Screenshot%201.png?raw=true)
![Screenshot](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/Screenshot%209.png?raw=true)
Fullscreen/esc key stays docked to the left, followed by buttons in the scrollable area, followed by widgets and finally by finder controls at the end of the scrollable area. The weather widget displays degrees in Fahrenheit and opens the Carrot menubar item, and the Date/Time widget opens the Fantastical 2 menubar item. I'd like to add integration with more apps in the future, too, but this is just my first attempt over the last few days.

Please give it a shot. Thank you 🙂