### PR TITLE
Add expanding function shelf screenshots, youtube support

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,9 @@ The brightness/volume up buttons were omitted from the slider in the interest of
 ![Screenshot](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/screenshot-1.png?raw=true)
 ![Screenshot](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/screenshot-2.png?raw=true)
 ![Screenshot](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/screenshot-4.png?raw=true)
-![Screenshot](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/screenshot-3.png?raw=true)
 ![Screenshot](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/screenshot-5.png?raw=true)
+![Screenshot](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/screenshot-3.png?raw=true)
+![Screenshot](https://github.com/GoldenChaos/GoldenChaos-BTT/blob/master/screenshot-6.png?raw=true)
 
 Supported apps:
 - Finder
@@ -229,6 +230,7 @@ Supported apps:
 - Firefox
 - iTunes
 - Spotify
+- YouTube (in Safari and as a Fluid app)
 - Reminders
 - Things 3
 - Carrot Weather
@@ -237,6 +239,7 @@ Supported apps:
 
 Nifty features:
 - Fullscreen button also acts as esc key, stays docked to the left
+- Hold down Option/Alt to expand the function shelf
 - Emoji button toggles a scrollable emoji widget
 - Date and Time widget toggles Fantastical 2 menu bar when pressed (uses Fantastical 2's default keyboard shortcut)
 - Weather widget shows condition emoji + temperature in Fahrenheit, toggles Carrot menu bar when pressed (uses Carrot's default keyboard shortcut)


### PR DESCRIPTION
Closed what I think is the final gap in basic functionality for my Touch Bar preset: greatly expanded function controls when you hold down the Option key. Also added YouTube support and a media player hierarchy for the Now Playing and Play/Pause widget, plus better icons for even more buttons.